### PR TITLE
Compile the `gl` module on non-wasm targets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod view;
 
 pub use view::Interactive;
 
-#[cfg(target_os="linux")]
+#[cfg(not(target_arch="wasm32"))]
 pub mod gl;
 
 #[cfg(not(target_arch="wasm32"))]


### PR DESCRIPTION
This is necessary to get it to compile on MacOS.